### PR TITLE
[Feat]#8 - 활동상세페이지 UI 구현

### DIFF
--- a/Run-It.xcodeproj/project.pbxproj
+++ b/Run-It.xcodeproj/project.pbxproj
@@ -7,12 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B9888242B8B76A300B2BC74 /* EventViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888232B8B76A300B2BC74 /* EventViewCell.swift */; };
 		0BF25AC42B8B65A600B0C8CE /* RunningMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF25AC32B8B65A600B0C8CE /* RunningMapView.swift */; };
 		0BF25AC62B8B73E600B0C8CE /* RunningMapMobel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF25AC52B8B73E600B0C8CE /* RunningMapMobel.swift */; };
 		0BF25AC82B8BA87900B0C8CE /* AmenitiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF25AC72B8BA87900B0C8CE /* AmenitiesViewController.swift */; };
 		0BF25ACC2B8C724600B0C8CE /* DistanceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF25ACB2B8C724600B0C8CE /* DistanceCollectionViewCell.swift */; };
+		2B9888242B8B76A300B2BC74 /* EventViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888232B8B76A300B2BC74 /* EventViewCell.swift */; };
 		2B98882A2B8C770900B2BC74 /* RecordViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888292B8C770900B2BC74 /* RecordViewCell.swift */; };
+		2B9888472B904D8500B2BC74 /* RunningRecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888462B904D8500B2BC74 /* RunningRecordViewController.swift */; };
 		C82CEDC92B86FCB200B619AD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82CEDC82B86FCB200B619AD /* AppDelegate.swift */; };
 		C82CEDCB2B86FCB200B619AD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82CEDCA2B86FCB200B619AD /* SceneDelegate.swift */; };
 		C82CEDCD2B86FCB200B619AD /* MainTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82CEDCC2B86FCB200B619AD /* MainTabBarViewController.swift */; };
@@ -39,12 +40,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2B9888232B8B76A300B2BC74 /* EventViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewCell.swift; sourceTree = "<group>"; };
 		0BF25AC32B8B65A600B0C8CE /* RunningMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningMapView.swift; sourceTree = "<group>"; };
 		0BF25AC52B8B73E600B0C8CE /* RunningMapMobel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningMapMobel.swift; sourceTree = "<group>"; };
 		0BF25AC72B8BA87900B0C8CE /* AmenitiesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmenitiesViewController.swift; sourceTree = "<group>"; };
 		0BF25ACB2B8C724600B0C8CE /* DistanceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceCollectionViewCell.swift; sourceTree = "<group>"; };
+		2B9888232B8B76A300B2BC74 /* EventViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewCell.swift; sourceTree = "<group>"; };
 		2B9888292B8C770900B2BC74 /* RecordViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewCell.swift; sourceTree = "<group>"; };
+		2B9888462B904D8500B2BC74 /* RunningRecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRecordViewController.swift; sourceTree = "<group>"; };
 		C82CEDC52B86FCB200B619AD /* Run-It.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Run-It.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C82CEDC82B86FCB200B619AD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C82CEDCA2B86FCB200B619AD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 			children = (
 				C82CEDE32B86FD8800B619AD /* ProfileViewController.swift */,
 				2B9888292B8C770900B2BC74 /* RecordViewCell.swift */,
+				2B9888462B904D8500B2BC74 /* RunningRecordViewController.swift */,
 			);
 			path = ProfileView;
 			sourceTree = "<group>";
@@ -277,6 +280,7 @@
 				C82CEDCB2B86FCB200B619AD /* SceneDelegate.swift in Sources */,
 				0BF25AC62B8B73E600B0C8CE /* RunningMapMobel.swift in Sources */,
 				0BF25AC82B8BA87900B0C8CE /* AmenitiesViewController.swift in Sources */,
+				2B9888472B904D8500B2BC74 /* RunningRecordViewController.swift in Sources */,
 				C879CD032B88807B00DBFB82 /* PauseRunningHalfModalViewController.swift in Sources */,
 				C82CEDE02B86FD5100B619AD /* BookmarkViewController.swift in Sources */,
 			);

--- a/Run-It/ProfileView/ProfileViewController.swift
+++ b/Run-It/ProfileView/ProfileViewController.swift
@@ -482,8 +482,8 @@ extension ProfileViewController: UITableViewDelegate, UITableViewDataSource {
         return 120
     }
 
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        let recordVC = RunningRecordViewController()
-//        navigationController?.pushViewController(recordVC, animated: true)
-//    }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let recordVC = RunningRecordViewController()
+        navigationController?.pushViewController(recordVC, animated: true)
+    }
 }

--- a/Run-It/ProfileView/ProfileViewController.swift
+++ b/Run-It/ProfileView/ProfileViewController.swift
@@ -482,8 +482,8 @@ extension ProfileViewController: UITableViewDelegate, UITableViewDataSource {
         return 120
     }
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let recordVC = RunningRecordViewController()
-        navigationController?.pushViewController(recordVC, animated: true)
-    }
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        let recordVC = RunningRecordViewController()
+//        navigationController?.pushViewController(recordVC, animated: true)
+//    }
 }

--- a/Run-It/ProfileView/RunningRecordViewController.swift
+++ b/Run-It/ProfileView/RunningRecordViewController.swift
@@ -1,0 +1,227 @@
+//
+//  RunningRecordViewController.swift
+//  Run-It
+//
+//  Created by t2023-m0024 on 2/29/24.
+//
+
+import UIKit
+import SnapKit
+
+#if DEBUG
+import SwiftUI
+struct RPreview: UIViewControllerRepresentable {
+    
+    // 여기 ViewController를 변경해주세요
+    func makeUIViewController(context: Context) -> UIViewController {
+        RunningRecordViewController()
+    }
+    
+    func updateUIViewController(_ uiView: UIViewController,context: Context) {
+        // leave this empty
+    }
+}
+
+struct RunningRecordViewController_PreviewProvider: PreviewProvider {
+    static var previews: some View {
+        Group {
+            RPreview()
+                .edgesIgnoringSafeArea(.all)
+                .previewDisplayName("Preview")
+                .previewDevice(PreviewDevice(rawValue: "iPhone 12 Pro"))
+        }
+    }
+}
+#endif
+
+class RunningRecordViewController: UIViewController, UITextFieldDelegate {
+    // MARK: - Properties
+//    var viewModel: RecordViewModel!
+        
+    var userDate: UILabel = {
+        let label = UILabel()
+        label.text = "2024. 02. 20. (화), 00:00"
+        label.font = UIFont.systemFont(ofSize: 18)
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var recordTextField: UITextField = {
+        let textField = UITextField()
+        textField.font = UIFont.systemFont(ofSize: 18)
+        textField.textAlignment = .left
+        
+        textField.snp.makeConstraints { make in
+            make.height.equalTo(60)
+        }
+        
+        let editButton = UIButton(type: .system)
+        editButton.setImage(UIImage(systemName: "pencil"), for: .normal)
+        editButton.contentMode = .scaleAspectFit
+        editButton.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
+        
+        editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+        
+        let rightView = UIView(frame: CGRect(x: 0, y: 0, width: 32, height: 24)) // 오른쪽 뷰 크기 설정
+        rightView.addSubview(editButton)
+        editButton.center = rightView.center
+        
+        textField.rightView = rightView
+        textField.rightViewMode = .always
+        
+        textField.returnKeyType = .done
+        
+        let underlineView = UIView()
+        underlineView.backgroundColor = .gray
+        textField.addSubview(underlineView)
+        underlineView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.height.equalTo(1)
+        }
+        
+        return textField
+    }()
+    
+    var recordDistance: UILabel = {
+        let label = UILabel()
+        label.text = "10.00"
+        label.font = UIFont.systemFont(ofSize: 128)
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var distanceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "킬로미터"
+        label.font = UIFont.systemFont(ofSize: 18)
+        label.textColor = UIColor.secondaryLabel
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var recordTime: UILabel = {
+        let label = UILabel()
+        label.text = "58:42"
+        label.font = UIFont.systemFont(ofSize: 45)
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var timeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "시간"
+        label.font = UIFont.systemFont(ofSize: 18)
+        label.textColor = UIColor.secondaryLabel
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var userPace: UILabel = {
+        let label = UILabel()
+        label.text = "05:52"
+        label.font = UIFont.systemFont(ofSize: 45)
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var paceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "평균 페이스"
+        label.font = UIFont.systemFont(ofSize: 18)
+        label.textColor = UIColor.secondaryLabel
+        label.textAlignment = .left
+        return label
+    }()
+    
+    var routeImage: UIImageView = {
+        let image = UIImageView()
+        image.backgroundColor = UIColor.systemGreen
+        return image
+    }()
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        recordTextField.text = userDate.text
+        recordTextField.delegate = self
+        // 텍스트 필드 편집 상태 감지를 위한 옵저버 추가
+        NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidBeginEditing), name: UITextField.textDidBeginEditingNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidEndEditing), name: UITextField.textDidEndEditingNotification, object: nil)
+    }
+    
+    @objc func backButtonTapped() {
+        self.dismiss(animated: true)
+    }
+    // MARK: - UI Setup
+    private func setupView() {
+        view.backgroundColor = .white
+        navigationItem.title = "Run it"
+        setupRecordStackView()
+    }
+    func setupRecordStackView(){
+        let userInfoStackView = UIStackView(arrangedSubviews: [userDate, recordTextField])
+        userInfoStackView.axis = .vertical
+        userInfoStackView.spacing = 5.0
+        
+        let distanceStackView = UIStackView(arrangedSubviews: [recordDistance, distanceLabel])
+        distanceStackView.axis = .vertical
+        
+        let timeStackView = UIStackView(arrangedSubviews: [recordTime, timeLabel])
+        timeStackView.axis = .vertical
+        
+        let paceStackView = UIStackView(arrangedSubviews: [userPace, paceLabel])
+        paceStackView.axis = .vertical
+        
+        let stackView = UIStackView(arrangedSubviews: [userInfoStackView, distanceStackView,timeStackView,paceStackView])
+        stackView.axis = .vertical
+        stackView.spacing = 16.0
+        
+        view.addSubview(stackView)
+        
+        stackView.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).offset(20)
+            make.left.equalToSuperview().offset(20)
+            make.right.equalToSuperview().offset(-20)
+        }
+        
+        view.addSubview(routeImage)
+        
+        routeImage.snp.makeConstraints{ make in
+            make.top.equalTo(stackView.snp.bottom).offset(20)
+            make.left.equalToSuperview().offset(20)
+            make.right.equalToSuperview().offset(-20)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-20)
+        }
+    }
+    // MARK: - UITextFieldDelegate
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+    // MARK: - @objc
+    @objc func editButtonTapped(sender: UIButton) {
+        if recordTextField.isFirstResponder {
+            recordTextField.resignFirstResponder() // Hide keyboard and end editing mode
+            recordTextField.text = "" // Clear text field content
+            sender.setImage(UIImage(systemName: "pencil"), for: .normal) // Change icon to pencil
+        } else {
+            recordTextField.becomeFirstResponder() // Set text field to editing mode
+            sender.setImage(UIImage(systemName: "xmark"), for: .normal) // Change icon to X
+        }
+    }
+
+    @objc private func textFieldDidBeginEditing(notification: NSNotification) {
+        // 텍스트 필드가 편집 모드일 때 X 아이콘으로 변경
+        if let textField = notification.object as? UITextField, textField == recordTextField {
+            let rightButton = textField.rightView?.subviews.compactMap { $0 as? UIButton }.first
+            rightButton?.setImage(UIImage(systemName: "xmark"), for: .normal)
+        }
+    }
+    
+    @objc private func textFieldDidEndEditing(notification: NSNotification) {
+        // 텍스트 필드 편집이 종료될 때 펜슬 아이콘으로 변경
+        if let textField = notification.object as? UITextField, textField == recordTextField {
+        }
+    }
+}


### PR DESCRIPTION
<!--
  Assignees - 본인 선택하기
  ReviewWers - 팀원 선택하기
-->
## Contents
<!-- 작업 사항에 대한 설명을 적어주세요 --> 
러닝기록에 대한 상세페이지 입니다.
이동경로도 로딩할 수 있도록 뷰를 추가하였습니다.

## Screenshots
<!-- 작업 사항에 대한 스크린샷을 첨부해주세요 --> 
<img width="220" alt="스크린샷 2024-02-29 오후 2 38 25" src="https://github.com/Run-Eat/Run-It/assets/151702566/00df98f1-f75f-4908-a665-256f0bdf7309">


## To Reviewers
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이나 논의할 부분이 있다면 적어주세요 --> 
ProfileViewController 의 활동기록을 누르면 나오는 상세페이지입니다.
ProfileViewController 의 화면전환 숨김해제했습니다.
작동 이상없습니다.

## Issues
<!-- 이슈가 발생하는 부분이 있다면 적어주세요 -->
추가구현사항으로 방문음식점을 넣을 수 있는 방법에 대하여 사용자가 러닝 종료시 선택할 수 있도록 하는 방법이 있을 것 같습니다.
