### PR TITLE
Feat#27-ActivityRecordList-DummyData-CoreDataManagerClass

### DIFF
--- a/Run-It.xcodeproj/project.pbxproj
+++ b/Run-It.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0BF25AC82B8BA87900B0C8CE /* StoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF25AC72B8BA87900B0C8CE /* StoreViewController.swift */; };
 		0BF25ACC2B8C724600B0C8CE /* DistanceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF25ACB2B8C724600B0C8CE /* DistanceCollectionViewCell.swift */; };
 		2B03B6D32B95D54F009F237A /* FavoriteViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B03B6D22B95D54F009F237A /* FavoriteViewCell.swift */; };
+		2B4652F92B96B64F0040B146 /* RunningRecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B4652F82B96B64F0040B146 /* RunningRecordViewModel.swift */; };
 		2B9888242B8B76A300B2BC74 /* EventViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888232B8B76A300B2BC74 /* EventViewCell.swift */; };
 		2B98882A2B8C770900B2BC74 /* RecordViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888292B8C770900B2BC74 /* RecordViewCell.swift */; };
 		2B9888472B904D8500B2BC74 /* RunningRecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9888462B904D8500B2BC74 /* RunningRecordViewController.swift */; };
@@ -81,6 +82,7 @@
 		0BF25AC72B8BA87900B0C8CE /* StoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreViewController.swift; sourceTree = "<group>"; };
 		0BF25ACB2B8C724600B0C8CE /* DistanceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceCollectionViewCell.swift; sourceTree = "<group>"; };
 		2B03B6D22B95D54F009F237A /* FavoriteViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewCell.swift; sourceTree = "<group>"; };
+		2B4652F82B96B64F0040B146 /* RunningRecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRecordViewModel.swift; sourceTree = "<group>"; };
 		2B9888232B8B76A300B2BC74 /* EventViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventViewCell.swift; sourceTree = "<group>"; };
 		2B9888292B8C770900B2BC74 /* RecordViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewCell.swift; sourceTree = "<group>"; };
 		2B9888462B904D8500B2BC74 /* RunningRecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRecordViewController.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				C82CEDE32B86FD8800B619AD /* ProfileViewController.swift */,
 				2B9888292B8C770900B2BC74 /* RecordViewCell.swift */,
 				2B9888462B904D8500B2BC74 /* RunningRecordViewController.swift */,
+				2B4652F82B96B64F0040B146 /* RunningRecordViewModel.swift */,
 			);
 			path = ProfileView;
 			sourceTree = "<group>";
@@ -410,6 +413,7 @@
 				C879CD032B88807B00DBFB82 /* PauseRunningHalfModalViewController.swift in Sources */,
 				C82CEDE02B86FD5100B619AD /* BookmarkViewController.swift in Sources */,
 				6C7A43E32B8C903100A14291 /* LoginViewController.swift in Sources */,
+				2B4652F92B96B64F0040B146 /* RunningRecordViewModel.swift in Sources */,
 				C893A7232B955B0E00D5466E /* RunningTimerManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Run-It/CoreDataManager.swift
+++ b/Run-It/CoreDataManager.swift
@@ -118,4 +118,43 @@ class CoreDataManager {
             return []
         }
     }
+    
+    func generateDummyRunningRecords() {
+        // 더미 데이터 배열
+        let dummyData = [
+            (time: 3600, distance: 10.0, pace: 6.0), // 1시간, 10km, 페이스 6분/km
+            (time: 1800, distance: 5.0, pace: 6.0),  // 30분, 5km, 페이스 6분/km
+            (time: 5400, distance: 15.0, pace: 6.0) // 1시간 30분, 15km, 페이스 6분/km
+        ]
+        
+        // 각 더미 데이터에 대해 RunningRecord 인스턴스 생성
+        for data in dummyData {
+            _ = createRunningRecord(time: data.time, distance: data.distance, pace: data.pace)
+        }
+        
+        // 변경 사항 저장
+        saveContext()
+    }
+    // MARK: - Delete RunningRecord in CoreDataManager
+    func deleteRunningRecord(withId id: UUID, completion: (Bool) -> Void) {
+        let context = persistentContainer.viewContext
+        let fetchRequest: NSFetchRequest<RunningRecord> = RunningRecord.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        
+        do {
+            let records = try context.fetch(fetchRequest)
+            if let recordToDelete = records.first {
+                context.delete(recordToDelete)
+                try context.save()
+                completion(true)
+            } else {
+                print("No record found with the specified ID.")
+                completion(false)
+            }
+        } catch {
+            print("Failed to delete running record: \(error)")
+            completion(false)
+        }
+    }
+
 }

--- a/Run-It/ProfileView/RecordViewCell.swift
+++ b/Run-It/ProfileView/RecordViewCell.swift
@@ -15,7 +15,6 @@ class RecordViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 16, weight: .bold)
-        label.text = "2024.02.23"
         label.numberOfLines = 0
         return label
     }()
@@ -24,7 +23,6 @@ class RecordViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 14)
-        label.text = "10.00 km"
         label.textAlignment = .right
         return label
     }()
@@ -33,7 +31,6 @@ class RecordViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 14)
-        label.text = "58:42 시간"
         label.textAlignment = .right
         return label
     }()
@@ -47,11 +44,6 @@ class RecordViewCell: UITableViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - Cell Configuration
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
     }
     
     private func setupUI() {
@@ -93,5 +85,14 @@ class RecordViewCell: UITableViewCell {
         backgroundView.layer.masksToBounds = true
         backgroundView.frame = self.bounds.inset(by: UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0))
         self.backgroundView = backgroundView
+    }
+}
+
+extension RecordViewCell {
+    func configure(with viewModel: RunningRecordViewModel) {
+        dateLabel.text = viewModel.dateText
+        distanceLabel.text = viewModel.distanceText
+        timeLabel.text = viewModel.timeText
+//        paceLabel.text = viewModel.paceText
     }
 }

--- a/Run-It/ProfileView/RunningRecordViewController.swift
+++ b/Run-It/ProfileView/RunningRecordViewController.swift
@@ -36,11 +36,14 @@ struct RunningRecordViewController_PreviewProvider: PreviewProvider {
 
 class RunningRecordViewController: UIViewController, UITextFieldDelegate {
     // MARK: - Properties
-//    var viewModel: RecordViewModel!
+    var viewModel: RunningRecordViewModel! {
+        didSet {
+            updateUI()
+        }
+    }
         
     var userDate: UILabel = {
         let label = UILabel()
-        label.text = "2024. 02. 20. (화), 00:00"
         label.font = UIFont.systemFont(ofSize: 18)
         label.textAlignment = .left
         return label
@@ -60,7 +63,7 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
         editButton.contentMode = .scaleAspectFit
         editButton.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
         
-        editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+        editButton.addTarget(RunningRecordViewController.self, action: #selector(editButtonTapped), for: .touchUpInside)
         
         let rightView = UIView(frame: CGRect(x: 0, y: 0, width: 32, height: 24)) // 오른쪽 뷰 크기 설정
         rightView.addSubview(editButton)
@@ -84,8 +87,7 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
     
     var recordDistance: UILabel = {
         let label = UILabel()
-        label.text = "10.00"
-        label.font = UIFont.systemFont(ofSize: 128)
+        label.font = UIFont.systemFont(ofSize: 85)
         label.textAlignment = .left
         return label
     }()
@@ -101,7 +103,6 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
     
     var recordTime: UILabel = {
         let label = UILabel()
-        label.text = "58:42"
         label.font = UIFont.systemFont(ofSize: 45)
         label.textAlignment = .left
         return label
@@ -118,7 +119,6 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
     
     var userPace: UILabel = {
         let label = UILabel()
-        label.text = "05:52"
         label.font = UIFont.systemFont(ofSize: 45)
         label.textAlignment = .left
         return label
@@ -133,10 +133,10 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
         return label
     }()
     
-    var routeImage: UIImageView = {
-        let image = UIImageView()
-        image.backgroundColor = UIColor.systemGreen
-        return image
+    var routeImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = UIColor.systemGreen
+        return imageView
     }()
     // MARK: - Life Cycle
     override func viewDidLoad() {
@@ -184,17 +184,41 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
             make.right.equalToSuperview().offset(-20)
         }
         
-        view.addSubview(routeImage)
+        view.addSubview(routeImageView)
         
-        routeImage.snp.makeConstraints{ make in
+        routeImageView.snp.makeConstraints{ make in
             make.top.equalTo(stackView.snp.bottom).offset(20)
             make.left.equalToSuperview().offset(20)
             make.right.equalToSuperview().offset(-20)
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-20)
         }
     }
+    // MARK: - UI업데이트
+    private func updateUI() {
+        guard let viewModel = viewModel else { return }
+        userDate.text = viewModel.dateText
+        recordDistance.text = viewModel.distanceText
+        recordTime.text = viewModel.timeText
+        userPace.text = viewModel.paceText
+//        routeImage.image = viewModel.routeImageData.flatMap(UIImage.init)
+        if let imageData = viewModel.routeImageData {
+            routeImageView.image = UIImage(data: imageData)
+        } else {
+            routeImageView.image = nil // Or set a placeholder image
+        }
+    }
     // MARK: - UITextFieldDelegate
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        // Assume textField is recordTextField and it's editing the label
+        if let newText = textField.text, !newText.isEmpty {
+            // Update the viewModel and persist the new label
+            viewModel.updateLabelText(newLabelText: newText)
+            print("라벨 저장")
+            
+            // Optionally, refresh UI elements that depend on labelText
+            // e.g., if you have a UILabel that displays labelText
+        }
+        
         textField.resignFirstResponder()
         return true
     }

--- a/Run-It/ProfileView/RunningRecordViewModel.swift
+++ b/Run-It/ProfileView/RunningRecordViewModel.swift
@@ -1,0 +1,108 @@
+//
+//  RunningRecordViewModel.swift
+//  Run-It
+//
+//  Created by t2023-m0024 on 3/5/24.
+//
+
+import Foundation
+
+import CoreData
+
+class RunningRecordViewModel {
+    // 뷰에 표시될 속성들
+    var id: UUID
+    var dateText: String
+    var labelText: String
+    var distanceText: String
+    var timeText: String
+    var paceText: String
+    var routeImageData: Data?
+    
+    init(runningRecord: RunningRecord) {
+        self.id = runningRecord.id ?? UUID()
+        self.dateText = RunningRecordViewModel.dateFormatter.string(from: runningRecord.date ?? Date())
+        self.labelText = runningRecord.label ?? dateText
+        self.distanceText = String(format: "%.2f km", runningRecord.distance)
+        self.timeText = RunningRecordViewModel.timeFormatter.string(from: TimeInterval(runningRecord.time)) ?? "N/A"
+        let paceMinutes = Int(runningRecord.pace) / 60
+        let paceSeconds = Int(runningRecord.pace) % 60
+        self.paceText = String(format: "%02d:%02d min/km", paceMinutes, paceSeconds)
+        self.routeImageData = runningRecord.routeImage
+    }
+    
+    private var runningRecords: [RunningRecord] = []
+    
+    func fetchRunningRecords(completion: @escaping () -> Void) {
+        runningRecords = CoreDataManager.shared.fetchRunningRecords()
+        // 최신 레코드를 사용해 뷰모델의 속성 설정
+        if let latestRecord = runningRecords.last {
+            configure(with: latestRecord)
+        }
+        completion()
+    }
+    
+    private func configure(with record: RunningRecord) {
+        dateText = labelText
+        distanceText = String(format: "%.2f km", record.distance)
+        timeText = RunningRecordViewModel.timeFormatter.string(from: TimeInterval(record.time)) ?? "N/A"
+        let paceMinutes = Int(record.pace) / 60
+        let paceSeconds = Int(record.pace) % 60
+        paceText = String(format: "%02d:%02d min/km", paceMinutes, paceSeconds)
+        routeImageData = record.routeImage
+    }
+    
+    func updateLabelText(newLabelText: String) {
+        // Update the viewModel's labelText
+        self.labelText = newLabelText
+        
+        // Find the RunningRecord entity with the current ID and update its label
+        let context = CoreDataManager.shared.persistentContainer.viewContext
+        let fetchRequest: NSFetchRequest<RunningRecord> = RunningRecord.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", self.id as CVarArg)
+        
+        do {
+            let results = try context.fetch(fetchRequest)
+            if let recordToUpdate = results.first {
+                recordToUpdate.label = newLabelText
+                try context.save()
+            }
+        } catch let error as NSError {
+            print("Updating label failed: \(error), \(error.userInfo)")
+        }
+    }
+    
+    // MARK: - Delete RunningRecord
+    func deleteRunningRecord(at index: Int, completion: @escaping (Bool) -> Void) {
+        // Assuming you have an array of RunningRecords in your viewModel
+        let recordToDelete = runningRecords[index]
+        
+        // Delete from Core Data
+        if let recordId = recordToDelete.id {
+            CoreDataManager.shared.deleteRunningRecord(withId: recordId) { success in
+                // Handle the deletion result
+            }
+        } else {
+            // Handle the case where recordToDelete.id is nil
+            print("Record ID is nil, cannot delete.")
+        }
+    }
+
+
+}
+// MARK: - Helper Methods
+extension RunningRecordViewModel {
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy. MM. dd. (E), HH:mm"
+        return formatter
+    }()
+    
+    private static var timeFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        return formatter
+    }()
+}

--- a/Run-It/Run_It.xcdatamodeld/Run_It.xcdatamodel/contents
+++ b/Run-It/Run_It.xcdatamodeld/Run_It.xcdatamodel/contents
@@ -5,7 +5,7 @@
     </entity>
     <entity name="Favorite" representedClassName="Favorite" parentEntity="User" syncable="YES" codeGenerationType="class">
         <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="favorite" inverseEntity="User"/>
     </entity>
     <entity name="PlaceInfo" representedClassName="PlaceInfo" syncable="YES" codeGenerationType="class">
         <attribute name="adress" optional="YES" attributeType="String"/>
@@ -39,6 +39,6 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="profilePhoto" optional="YES" attributeType="Binary"/>
         <attribute name="userId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <relationship name="favorite" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Favorite"/>
+        <relationship name="favorite" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Favorite" inverseName="user" inverseEntity="Favorite"/>
     </entity>
 </model>


### PR DESCRIPTION
Made-RunningRecordViewModel-Class

<!--
  Assignees - 본인 선택하기
  ReviewWers - 팀원 선택하기
-->

## Contents
<!-- 작업 사항에 대한 설명을 적어주세요 --> 
프로필뷰 활동기록 테이블뷰 더미데이터로 생성 및 활동상세페이지도 해당 정보로 로딩
더미정보는 CoreDataManager에 있음
관련하여 ViewModel Class 생성
코어데이터 엔터티간 인버스오류 수정 (user-favorite)

## Screenshots
<!-- 작업 사항에 대한 스크린샷을 첨부해주세요 --> 
<img width="298" alt="스크린샷 2024-03-05 오전 11 13 16" src="https://github.com/Run-Eat/Run-It/assets/151702566/05752efa-8d48-4e55-b35f-969bef8e83ce">
<img width="308" alt="스크린샷 2024-03-05 오전 11 13 27" src="https://github.com/Run-Eat/Run-It/assets/151702566/6565f9ea-74b3-4cca-b4e5-d908ca5747d3">


## To Reviewers
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이나 논의할 부분이 있다면 적어주세요 --> 
프로필뷰에 뷰디드로드에서 더미데이터 로딩 부분 있습니다. 필요없으면 지우셔도 됩니다!
## Issues
<!-- 이슈가 발생하는 부분이 있다면 적어주세요 -->
활동기록 상세페이지에서 라벨을 수정하면 활동기록리스트의 날짜를 라벨로 변경되도록 추후 수정예정입니다.
  
