### PR TITLE
Fix#103-RunningRecordViewLayout

### DIFF
--- a/Run-It/ProfileView/ProfileViewController.swift
+++ b/Run-It/ProfileView/ProfileViewController.swift
@@ -133,6 +133,7 @@ class ProfileViewController: UIViewController
     {
         let lineView = UIView()
         lineView.backgroundColor = UIColor.label
+        lineView.alpha = 0.7
         return lineView
     }()
     
@@ -361,22 +362,21 @@ class ProfileViewController: UIViewController
             make.leading.equalTo(view.snp.leading).inset(20)
         }
         
-        weeklyButton.snp.makeConstraints
-        {   make in
+        weeklyButton.snp.makeConstraints { make in
             make.width.equalTo(100)
             make.height.equalTo(30)
-            make.top.equalTo(totalRunningDistanceLabel.snp.bottom).offset(20)
-            make.leading.equalTo(view.snp.leading).inset(100)
+            make.top.equalTo(totalRunningDistanceLabel.snp.bottom).offset(32)
+            // weeklyButton은 뷰의 중앙에서 왼쪽으로 (50/2)인 25만큼 이동
+            make.centerX.equalToSuperview().offset(-25 - 50) // 50은 두 버튼 사이의 간격
         }
         
-        monthlyButton.snp.makeConstraints
-        {   make in
+        monthlyButton.snp.makeConstraints { make in
             make.width.equalTo(100)
             make.height.equalTo(30)
-            make.top.equalTo(weeklyButton.snp.top).offset(0)
-            make.trailing.equalTo(weeklyButton.snp.trailing).offset(150)
+            make.top.equalTo(weeklyButton.snp.top)
+            make.leading.equalTo(weeklyButton.snp.trailing).offset(50)
         }
-
+        
         resetButton.snp.makeConstraints
         {   make in
             make.centerY.equalTo(pointImage.snp.centerY)

--- a/Run-It/ProfileView/RunningRecordViewController.swift
+++ b/Run-It/ProfileView/RunningRecordViewController.swift
@@ -29,7 +29,7 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
         textField.textAlignment = .left
         
         textField.snp.makeConstraints { make in
-            make.height.equalTo(90)
+            make.height.equalTo(60)
         }
         
         let editButton = UIButton(type: .system)
@@ -138,7 +138,7 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
     func setupRecordStackView(){
         let userInfoStackView = UIStackView(arrangedSubviews: [userDate, recordTextField])
         userInfoStackView.axis = .vertical
-        userInfoStackView.spacing = 5.0
+//        userInfoStackView.spacing = 5.0
         
         let distanceStackView = UIStackView(arrangedSubviews: [recordDistance, distanceLabel])
         distanceStackView.axis = .vertical
@@ -151,7 +151,7 @@ class RunningRecordViewController: UIViewController, UITextFieldDelegate {
         
         let stackView = UIStackView(arrangedSubviews: [userInfoStackView, distanceStackView,timeStackView,paceStackView])
         stackView.axis = .vertical
-        stackView.spacing = 8.0
+//        stackView.spacing = 8.0
         
         view.addSubview(stackView)
         


### PR DESCRIPTION
<!--
  Assignees - 본인 선택하기
  ReviewWers - 팀원 선택하기
-->

## Contents
<!-- 작업 사항에 대한 설명을 적어주세요 --> 
활동기록상세뷰의 스택뷰 레이아웃을 조정하여 아이폰 8 Plus 및 아이폰 15 Pro에서도 컨텐츠가 모두 보입니다.
프로필뷰의 주간/월간 버튼 레이아웃을 중앙정렬했습니다. 

## Screenshots
<!-- 작업 사항에 대한 스크린샷을 첨부해주세요 --> 
<img width="333" alt="스크린샷 2024-03-21 오전 10 50 00" src="https://github.com/Run-Eat/Run-It/assets/151702566/da14a828-d417-4b60-85f3-34bf24e627f7">
<img width="335" alt="스크린샷 2024-03-21 오전 10 49 19" src="https://github.com/Run-Eat/Run-It/assets/151702566/5194fb48-6e08-4610-897a-efa329b70c51">


## To Reviewers
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이나 논의할 부분이 있다면 적어주세요 --> 


## Issues
<!-- 이슈가 발생하는 부분이 있다면 적어주세요 -->

  
