### PR TITLE
Fix#127-Layout,DarkMode

### DIFF
--- a/Run-It/BookmarkView/BookmarkViewController.swift
+++ b/Run-It/BookmarkView/BookmarkViewController.swift
@@ -14,6 +14,22 @@ class BookmarkViewController: UIViewController, UITableViewDataSource, UITableVi
     var favoritesViewModel = FavoritesViewModel()
     var favoriteRecords: [Favorite] = []
     
+    lazy var favoriteLabel: UILabel = {
+        let label = UILabel()
+        label.text = "즐겨찾기"
+        label.font = UIFont.systemFont(ofSize: 25, weight: .bold)
+        label.textColor = .label
+        label.textAlignment = .left
+        
+        return label
+    }()
+    
+    lazy var imageBar: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = UIColor.systemGray6
+        return imageView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
@@ -33,6 +49,8 @@ class BookmarkViewController: UIViewController, UITableViewDataSource, UITableVi
     }
     
     func setupFavoriteListUI() {
+        view.addSubview(favoriteLabel)
+        view.addSubview(imageBar)
         view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
@@ -41,32 +59,42 @@ class BookmarkViewController: UIViewController, UITableViewDataSource, UITableVi
         tableView.backgroundColor = UIColor.systemBackground
         tableView.isScrollEnabled = true
         
+        favoriteLabel.snp.makeConstraints{ make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(20)
+        }
+        imageBar.snp.makeConstraints { make in
+            make.top.equalTo(favoriteLabel.snp.bottom).offset(8)
+            make.left.right.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(8)
+        }
         tableView.snp.makeConstraints { make in
-            make.top.left.right.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(imageBar.snp.bottom)
+            make.left.right.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
     
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 40
-    }
-
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerView = UIView()
-        headerView.backgroundColor = UIColor.systemBlue
-
-        let label = UILabel()
-        label.text = "즐겨찾기"
-        label.font = UIFont.systemFont(ofSize: 25)
-        label.textColor = UIColor.label
-        label.textAlignment = .left
-        headerView.addSubview(label)
-
-        label.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 20))
-        }
-
-        return headerView
-    }
+//    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+//        return 40
+//    }
+//
+//    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+//        let headerView = UIView()
+//        headerView.backgroundColor = UIColor.systemBackground
+//
+//        let label = UILabel()
+//        label.text = "즐겨찾기"
+//        label.font = UIFont.systemFont(ofSize: 25)
+//        label.textColor = UIColor.label
+//        label.textAlignment = .left
+//        headerView.addSubview(label)
+//
+//        label.snp.makeConstraints { make in
+//            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 20))
+//        }
+//
+//        return headerView
+//    }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         favoriteRecords.count
@@ -100,7 +128,7 @@ class BookmarkViewController: UIViewController, UITableViewDataSource, UITableVi
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 130
+        return 122
     }
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {

--- a/Run-It/BookmarkView/FavoriteViewCell.swift
+++ b/Run-It/BookmarkView/FavoriteViewCell.swift
@@ -72,7 +72,7 @@ class FavoriteViewCell: UITableViewCell {
     private func setupLayout() {
         
         nameLabel.snp.makeConstraints { make in
-            make.top.equalTo(contentView.snp.top).offset(15)
+            make.top.equalTo(contentView.snp.top).offset(16)
             make.leading.equalTo(contentView.snp.leading).offset(16)
             make.trailing.equalTo(storeImage.snp.leading).offset(-16)
             make.height.equalTo(18)
@@ -81,19 +81,20 @@ class FavoriteViewCell: UITableViewCell {
         categoryLabel.snp.makeConstraints { make in
             make.top.equalTo(nameLabel.snp.bottom).offset(4)
             make.leading.equalTo(contentView.snp.leading).offset(16)
-            make.height.equalTo(18)
+            make.height.equalTo(15)
         }
         
         adressLabel.snp.makeConstraints { make in
             make.top.equalTo(categoryLabel.snp.bottom).offset(4)
             make.leading.equalTo(contentView.snp.leading).offset(16)
             make.trailing.equalTo(storeImage.snp.leading).offset(-16)
-            make.height.equalTo(60)
+            make.height.equalTo(50)
         }
         
         storeImage.snp.makeConstraints { make in
             make.top.equalTo(contentView.snp.top).offset(16)
             make.trailing.equalTo(contentView.snp.trailing).offset(-16)
+            make.bottom.equalTo(contentView.snp.top).offset(-16)
             make.width.height.equalTo(90)
         }
 

--- a/Run-It/LoginView/LoginViewController.swift
+++ b/Run-It/LoginView/LoginViewController.swift
@@ -40,7 +40,8 @@ class LoginViewController: UIViewController
         textField.spellCheckingType = .no
         textField.layer.borderWidth = 0.7
         textField.layer.cornerRadius = 7
-        textField.backgroundColor = UIColor.white
+        textField.backgroundColor = UIColor.systemBackground
+        textField.textColor = UIColor.label
         return textField
     }()
     
@@ -59,7 +60,8 @@ class LoginViewController: UIViewController
         textField.isSecureTextEntry = true
         textField.layer.borderWidth = 0.7
         textField.layer.cornerRadius = 7
-        textField.backgroundColor = UIColor.white
+        textField.backgroundColor = UIColor.systemBackground
+        textField.textColor = UIColor.label
         return textField
     }()
     
@@ -98,7 +100,7 @@ class LoginViewController: UIViewController
     {
         let button = UIButton()
         button.setTitle("비밀번호 재설정", for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.label, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 15)
         button.addTarget(self, action: #selector(touchedResetPasswordButton), for: .touchUpInside)
         return button
@@ -108,7 +110,7 @@ class LoginViewController: UIViewController
     {
         let button = UIButton()
         button.setTitle("회원가입", for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.label, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 15)
         button.addTarget(self, action: #selector(touchedSignUpButton), for: .touchUpInside)
         return button
@@ -117,14 +119,14 @@ class LoginViewController: UIViewController
     let leftLine_verticality: UIView =
     {
         let lineView = UIView()
-        lineView.backgroundColor = UIColor.black
+        lineView.backgroundColor = UIColor.label
         return lineView
     }()
     
     let rightLine_verticality: UIView =
     {
         let lineView = UIView()
-        lineView.backgroundColor = UIColor.black
+        lineView.backgroundColor = UIColor.label
         return lineView
     }()
     
@@ -133,21 +135,21 @@ class LoginViewController: UIViewController
         let label = UILabel()
         label.text = "또는 소셜 계정으로 로그인"
         label.font = UIFont.systemFont(ofSize: CGFloat(14))
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         return label
     }()
     
     let leftLine: UIView =
     {
         let lineView = UIView()
-        lineView.backgroundColor = UIColor.black
+        lineView.backgroundColor = UIColor.label
         return lineView
     }()
     
     let rightLine: UIView =
     {
         let lineView = UIView()
-        lineView.backgroundColor = UIColor.black
+        lineView.backgroundColor = UIColor.label
         return lineView
     }()
     
@@ -162,8 +164,30 @@ class LoginViewController: UIViewController
     lazy var appleLoginButton: UIButton =
     {
         let button = UIButton()
-        button.setImage(UIImage(named: "AppleLogo"), for: .normal)
+        let logoImage = UIImage(systemName: "applelogo")
+        button.setImage(logoImage, for: .normal)
         button.addTarget(self, action: #selector(touchedAppleLoginButton), for: .touchUpInside)
+        let buttonSize: CGFloat = 40
+            button.frame = CGRect(x: 0, y: 0, width: buttonSize, height: buttonSize)
+        // cornerRadius를 버튼 높이의 절반으로 설정하여 원형으로 만듭니다.
+        button.layer.cornerRadius = buttonSize / 2
+        // 클립 투 바운즈를 true로 설정하여 레이어 바깥으로 내용이 표시되지 않도록 합니다.
+        button.clipsToBounds = true
+        if #available(iOS 13.0, *) {
+            // 초기 인터페이스 스타일에 따라 버튼의 색상을 설정합니다.
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            if userInterfaceStyle == .dark {
+                button.backgroundColor = .white
+                button.tintColor = .black
+            } else {
+                button.backgroundColor = .black
+                button.tintColor = .white
+            }
+        } else {
+            // iOS 13 미만에서는 기본 테마를 사용합니다.
+            button.backgroundColor = .black
+            button.tintColor = .white
+        }
         return button
     }()
     
@@ -171,13 +195,43 @@ class LoginViewController: UIViewController
     override func viewDidLoad()
     {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         
         addSubView()
         setLayout()
         registerObserver()
         addInputAccessoryForTextFields()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateTextFieldBorderColor()
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // 이전 트레이트 컬렉션과 현재 트레이트 컬렉션을 비교하여
+        // 색상 모드(다크 모드, 라이트 모드)가 변경되었는지 확인합니다.
+        if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            // 색상 모드가 변경되었다면 테두리 색상을 업데이트합니다.
+            updateTextFieldBorderColor()
+        }
+        
+        if #available(iOS 13.0, *) {
+            // 현재 트레이트 컬렉션을 가져와서 인터페이스 스타일을 확인합니다.
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            // 다크 모드일 때
+            if userInterfaceStyle == .dark {
+                appleLoginButton.backgroundColor = .white
+                appleLoginButton.tintColor = .black
+            } else { // 라이트 모드 또는 미정의일 때
+                appleLoginButton.backgroundColor = .black
+                appleLoginButton.tintColor = .white
+            }
+        }
+    }
+
 
 // MARK: - 레이아웃 설정
     func addSubView()
@@ -318,6 +372,18 @@ class LoginViewController: UIViewController
         
     }
     
+    func updateTextFieldBorderColor() {
+        emailTextField.layer.borderColor = (traitCollection.userInterfaceStyle == .dark)
+            ? UIColor.white.cgColor
+            : UIColor.black.cgColor
+        emailTextField.layer.borderWidth = 0.7
+        
+        passwordTextField.layer.borderColor = (traitCollection.userInterfaceStyle == .dark)
+            ? UIColor.white.cgColor
+            : UIColor.black.cgColor
+        passwordTextField.layer.borderWidth = 0.7
+    }
+    
 // MARK: - CoreData 데이터 확인 후 수정
     func checkData(loginType: String, email: String)
     {
@@ -418,7 +484,7 @@ class LoginViewController: UIViewController
         
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
         {
-            if let keyWindow = windowScene.windows.first 
+            if let keyWindow = windowScene.windows.first
             {
                 loginVM.setPresentationAnchor(keyWindow)
             }
@@ -444,7 +510,7 @@ class LoginViewController: UIViewController
     @objc func touchedResetPasswordButton()
     {
         let alertController = UIAlertController(title: "비밀번호 찾기", message: "이메일을 입력해주세요", preferredStyle: .alert)
-        alertController.addTextField 
+        alertController.addTextField
         {   textField in
             textField.placeholder = "이메일"
             textField.keyboardType = .emailAddress

--- a/Run-It/LoginView/SignUpViewController.swift
+++ b/Run-It/LoginView/SignUpViewController.swift
@@ -23,7 +23,7 @@ class SignUpViewController: UIViewController
         let button = UIButton()
         let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .large)
         button.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
-        button.tintColor = .black
+        button.tintColor = UIColor.label
         button.addTarget(self, action: #selector(cancelSignUp), for: .touchUpInside)
         return button
     }()
@@ -33,7 +33,7 @@ class SignUpViewController: UIViewController
         let label = UILabel()
         label.text = "회원가입"
         label.font = UIFont.systemFont(ofSize: CGFloat(17))
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         return label
     }()
     
@@ -43,7 +43,7 @@ class SignUpViewController: UIViewController
         label.text = "이메일과 비밀번호만으로 \nRUN IT에 가입할 수 있어요!"
         label.font = UIFont.systemFont(ofSize: CGFloat(21))
         label.numberOfLines = 2
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         return label
     }()
     
@@ -61,7 +61,8 @@ class SignUpViewController: UIViewController
         textField.spellCheckingType = .no
         textField.layer.borderWidth = 0.7
         textField.layer.cornerRadius = 7
-        textField.backgroundColor = UIColor.white
+        textField.backgroundColor = UIColor.systemBackground
+        textField.textColor = UIColor.label
         return textField
     }()
     
@@ -70,7 +71,7 @@ class SignUpViewController: UIViewController
         let label = UILabel()
         label.text = "정확한 이메일을 입력해주세요"
         label.font = UIFont.systemFont(ofSize: CGFloat(12))
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         return label
     }()
     
@@ -88,7 +89,8 @@ class SignUpViewController: UIViewController
         textField.spellCheckingType = .no
         textField.layer.borderWidth = 0.7
         textField.layer.cornerRadius = 7
-        textField.backgroundColor = UIColor.white
+        textField.backgroundColor = UIColor.systemBackground
+        textField.textColor = UIColor.label
         return textField
     }()
     
@@ -107,7 +109,7 @@ class SignUpViewController: UIViewController
         label.text = "비밀번호는 영문, 숫자, 특수문자를 포함해 8 - 20자 이내로 입력해주세요"
         label.font = UIFont.systemFont(ofSize: CGFloat(12))
         label.numberOfLines = 2
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         return label
     }()
     
@@ -127,21 +129,21 @@ class SignUpViewController: UIViewController
         let label = UILabel()
         label.text = "또는 소셜 계정으로 가입"
         label.font = UIFont.systemFont(ofSize: CGFloat(14))
-        label.textColor = UIColor.black
+        label.textColor = UIColor.label
         return label
     }()
     
     let leftLine: UIView =
     {
         let lineView = UIView()
-        lineView.backgroundColor = UIColor.black
+        lineView.backgroundColor = UIColor.label
         return lineView
     }()
     
     let rightLine: UIView =
     {
         let lineView = UIView()
-        lineView.backgroundColor = UIColor.black
+        lineView.backgroundColor = UIColor.label
         return lineView
     }()
     
@@ -156,8 +158,30 @@ class SignUpViewController: UIViewController
     lazy var appleSignupButton: UIButton =
     {
         let button = UIButton()
-        button.setImage(UIImage(named: "AppleLogo"), for: .normal)
+        let logoImage = UIImage(systemName: "applelogo")
+        button.setImage(logoImage, for: .normal)
         button.addTarget(self, action: #selector(touchedAppleSignupButton), for: .touchUpInside)
+        let buttonSize: CGFloat = 40
+            button.frame = CGRect(x: 0, y: 0, width: buttonSize, height: buttonSize)
+        // cornerRadius를 버튼 높이의 절반으로 설정하여 원형으로 만듭니다.
+        button.layer.cornerRadius = buttonSize / 2
+        // 클립 투 바운즈를 true로 설정하여 레이어 바깥으로 내용이 표시되지 않도록 합니다.
+        button.clipsToBounds = true
+        if #available(iOS 13.0, *) {
+            // 초기 인터페이스 스타일에 따라 버튼의 색상을 설정합니다.
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            if userInterfaceStyle == .dark {
+                button.backgroundColor = .white
+                button.tintColor = .black
+            } else {
+                button.backgroundColor = .black
+                button.tintColor = .white
+            }
+        } else {
+            // iOS 13 미만에서는 기본 테마를 사용합니다.
+            button.backgroundColor = .black
+            button.tintColor = .white
+        }
         return button
     }()
 
@@ -165,7 +189,7 @@ class SignUpViewController: UIViewController
     override func viewDidLoad()
     {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         
         addSubView()
         setLayout()
@@ -174,6 +198,36 @@ class SignUpViewController: UIViewController
         emailTextField.delegate = self
         passwordTextField.delegate = self
         passwordTextField.isSecureTextEntry = true
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateTextFieldBorderColor()
+    }
+    
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // 이전 트레이트 컬렉션과 현재 트레이트 컬렉션을 비교하여
+        // 색상 모드(다크 모드, 라이트 모드)가 변경되었는지 확인합니다.
+        if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            // 색상 모드가 변경되었다면 테두리 색상을 업데이트합니다.
+            updateTextFieldBorderColor()
+        }
+        
+        if #available(iOS 13.0, *) {
+            // 현재 트레이트 컬렉션을 가져와서 인터페이스 스타일을 확인합니다.
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            // 다크 모드일 때
+            if userInterfaceStyle == .dark {
+                appleSignupButton.backgroundColor = .white
+                appleSignupButton.tintColor = .black
+            } else { // 라이트 모드 또는 미정의일 때
+                appleSignupButton.backgroundColor = .black
+                appleSignupButton.tintColor = .white
+            }
+        }
     }
 
 // MARK: - 레이아웃 지정
@@ -298,6 +352,18 @@ class SignUpViewController: UIViewController
         }
     }
     
+    func updateTextFieldBorderColor() {
+        emailTextField.layer.borderColor = (traitCollection.userInterfaceStyle == .dark)
+            ? UIColor.white.cgColor
+            : UIColor.black.cgColor
+        emailTextField.layer.borderWidth = 0.7
+        
+        passwordTextField.layer.borderColor = (traitCollection.userInterfaceStyle == .dark)
+            ? UIColor.white.cgColor
+            : UIColor.black.cgColor
+        passwordTextField.layer.borderWidth = 0.7
+    }
+    
 // MARK: - 버튼 함수
     @objc func cancelSignUp()
     {
@@ -338,7 +404,7 @@ class SignUpViewController: UIViewController
     
     @objc func touchedKakaoSignupButton()
     {
-        if AuthApi.hasToken() 
+        if AuthApi.hasToken()
         {
             UserApi.shared.accessTokenInfo
             {   accessTokenInfo, error in
@@ -353,9 +419,9 @@ class SignUpViewController: UIViewController
                     // 토큰 유효성 체크 성공 (필요 시 토큰 갱신됨)
                 }
             }
-        } 
+        }
         
-        else 
+        else
         {
             kakaoSignup()
             dismiss(animated: true)
@@ -410,22 +476,22 @@ extension SignUpViewController: UITextFieldDelegate
             {
                 emailTextField.layer.borderColor = UIColor.green.cgColor
                 emailExplainLabel.text = "이메일 주소가 올바릅니다."
-            } 
+            }
             else
             {
                 emailTextField.layer.borderColor = UIColor.red.cgColor
                 emailExplainLabel.text = "올바른 이메일을 입력했는지 확인하세요."
             }
-        } 
+        }
         
         else if textField == passwordTextField
         {
-            if isPasswordValid 
+            if isPasswordValid
             {
                 
                 passwordTextField.layer.borderColor = UIColor.green.cgColor
                 passwordExplainLabel.text = "비밀번호가 올바릅니다."
-            } 
+            }
             else
             {
                 passwordTextField.layer.borderColor = UIColor.red.cgColor

--- a/Run-It/ProfileView/ProfileViewController.swift
+++ b/Run-It/ProfileView/ProfileViewController.swift
@@ -26,6 +26,17 @@ class ProfileViewController: UIViewController
     }
     private var stackView: UIStackView!
     // 총 뛴 거리
+    
+    lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "내 정보"
+        label.font = UIFont.systemFont(ofSize: 25, weight: .bold)
+        label.textColor = .label
+        label.textAlignment = .left
+        
+        return label
+    }()
+    
     var totalRunningDistance: Double = 0
 
     // 이번 주 데이터
@@ -97,7 +108,7 @@ class ProfileViewController: UIViewController
         return button
     }()
     
-    lazy var titleLabel = createLabel("내 정보", 35)
+//    lazy var titleLabel = createLabel("내 정보", 35)
     
     let profileImageView: UIImageView =
     {
@@ -215,6 +226,7 @@ class ProfileViewController: UIViewController
     {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+        view.addSubview(titleLabel)
         view.addSubview(scrollView)
         scrollView.contentSize = CGSize(width: view.frame.width, height: 2000)
         addScrollView()
@@ -226,13 +238,15 @@ class ProfileViewController: UIViewController
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        let uiViewHeight = CGFloat(runningRecords.count) * 170.0 + 16.0
+        let uiViewHeight = CGFloat(runningRecords.count) * 150 + 16.0
         let contentHeight = 671.33 + 44 + 8 + uiViewHeight
         scrollView.contentSize = CGSize(width: view.frame.width, height: contentHeight)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // 네비게이션 바 숨기기
+        navigationController?.setNavigationBarHidden(true, animated: animated)
         loadRunningRecords()
         displayProfileImage()
         statisticsManager(true)
@@ -251,6 +265,8 @@ class ProfileViewController: UIViewController
     
     override func viewWillDisappear(_ animated: Bool) {
         statisticsManager(false)
+        // 네비게이션 바 다시 보이기
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
    
     // MARK: - addSubView
@@ -260,7 +276,7 @@ class ProfileViewController: UIViewController
 //        scrollView.addSubview(noticeButton)
         scrollView.addSubview(loginTypeIcon)
         scrollView.addSubview(logoutButton)
-        scrollView.addSubview(titleLabel)
+//        scrollView.addSubview(titleLabel)
         scrollView.addSubview(profileImageView)
         scrollView.addSubview(imageSettingButton)
         scrollView.addSubview(pointImage)
@@ -280,15 +296,9 @@ class ProfileViewController: UIViewController
     {
         scrollView.snp.makeConstraints
         {   make in
-            make.edges.equalToSuperview()
+            make.top.equalTo(titleLabel.snp.bottom)
+            make.left.right.bottom.equalToSuperview()
         }
-        
-//        noticeButton.snp.makeConstraints
-//        {   make in
-//            make.top.equalTo(scrollView.snp.top)equalTo(scrollView.snp.top).inset(0)
-//            make.trailing.equalTo(view.snp.trailing).inset(20)
-//            make.width.equalTo(90)
-//        }
         
         loginTypeIcon.snp.makeConstraints
         {   make in
@@ -307,13 +317,15 @@ class ProfileViewController: UIViewController
         
         titleLabel.snp.makeConstraints
         {   make in
-            make.top.equalTo(scrollView.snp.top).offset(20)
-            make.centerX.equalTo(view.snp.centerX)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(20)
+//            make.top.equalTo(scrollView.snp.top).offset(20)
+//            make.centerX.equalTo(view.snp.centerX)
         }
         
         profileImageView.snp.makeConstraints
         {   make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(30)
+            make.top.equalToSuperview().offset(30)
             make.centerX.equalTo(view.snp.centerX)
             make.width.equalTo(150)
             make.height.equalTo(150)
@@ -321,7 +333,7 @@ class ProfileViewController: UIViewController
         
         imageSettingButton.snp.makeConstraints
         {   make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(145)
+            make.top.equalToSuperview().offset(145)
             make.trailing.equalTo(view.snp.trailing).inset(130)
             make.width.equalTo(35)
             make.height.equalTo(35)
@@ -343,7 +355,7 @@ class ProfileViewController: UIViewController
         
         statsLabel.snp.makeConstraints
         {   make in
-            make.top.equalTo(pointImage.snp.bottom).offset(20)
+            make.top.equalTo(pointImage.snp.bottom).offset(16)
             make.leading.equalTo(view.snp.leading).inset(20)
         }
         
@@ -413,18 +425,20 @@ class ProfileViewController: UIViewController
             make.top.equalTo(stackView.snp.bottom).offset(20)
             make.leading.equalToSuperview().offset(20)
         }
+        
         uiView.snp.makeConstraints { make in
             make.top.equalTo(userRecord.snp.bottom).offset(16)
             make.leading.equalTo(view.snp.leading)
             make.trailing.equalTo(view.snp.trailing)
-            make.height.equalTo(runningRecords.count * 170 + 16)
+            make.height.equalTo(runningRecords.count * 150 + 16)
         }
         
         tableView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(8)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
-            self.tableViewHeightConstraint = make.height.equalTo(runningRecords.count * 170).constraint
+            make.bottom.equalToSuperview()
+            self.tableViewHeightConstraint = make.height.equalTo(runningRecords.count * 150).constraint
         }
         
         withdrawButton.snp.makeConstraints
@@ -979,7 +993,7 @@ extension ProfileViewController {
         tableView.layoutIfNeeded()
         tableViewHeightConstraint?.update(offset: runningRecords.count * 170)
         uiView.snp.updateConstraints { make in
-            make.height.equalTo(runningRecords.count * 170 + 16)
+            make.height.equalTo(runningRecords.count * 150 + 16)
         }
         view.layoutIfNeeded()
     }
@@ -1018,7 +1032,7 @@ extension ProfileViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 170
+        return 150
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -1065,7 +1079,7 @@ extension ProfileViewController: UITableViewDelegate, UITableViewDataSource {
 // MARK: - 애플 엑세스 토큰 발급 응답 모델
 extension ProfileViewController
 {
-    struct AppleTokenResponse: Codable 
+    struct AppleTokenResponse: Codable
     {
         var access_token: String?
         var token_type: String?
@@ -1151,7 +1165,7 @@ extension ProfileViewController
                                 {
                                     completionHandler(refreshToken)
                                 }
-                                else 
+                                else
                                 {
                                     let alert = UIAlertController(title: "Error", message: "토큰 생성 실패", preferredStyle: .alert)
                                     let okayAction = UIAlertAction(title: "확인", style: .default, handler: {_ in})

--- a/Run-It/RunningMapView/RunningMapViewController.swift
+++ b/Run-It/RunningMapView/RunningMapViewController.swift
@@ -27,7 +27,7 @@ enum PresentView {
     case completed
 }
 
-class RunningMapViewController: UIViewController, MKMapViewDelegate, UIGestureRecognizerDelegate {
+class RunningMapViewController: UIViewController, MKMapViewDelegate, UIGestureRecognizerDelegate  {
     weak var parentVC: RunningTimerToMapViewPageController?
     
     var weatherViewModel = WeatherViewModel()
@@ -118,10 +118,10 @@ class RunningMapViewController: UIViewController, MKMapViewDelegate, UIGestureRe
     }()
     
     lazy var attributionURL: UIButton = {
-        let button = UIButton(type: .system) // 시스템 타입의 버튼을 생성합니다.
-        button.setTitle("Weather Attribution", for: .normal) // 버튼의 타이틀을 설정합니다.
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 11) // 타이틀의 폰트 크기를 설정합니다.
-        button.setTitleColor(.systemBlue, for: .normal) // 타이틀의 색상을 시스템 블루로 설정합니다.
+        let button = UIButton(type: .system)
+        button.setTitle("Weather Attribution", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 11)
+        button.setTitleColor(.systemBlue, for: .normal)
         button.addTarget(self, action: #selector(attributionTapped), for: .touchUpInside)
         return button
     }()
@@ -282,9 +282,20 @@ class RunningMapViewController: UIViewController, MKMapViewDelegate, UIGestureRe
         favoritesViewModel = FavoritesViewModel()
         RunningTimerLocationManager.shared.resetActivityTimer()
         mapView.setUserTrackingMode(.followWithHeading, animated: true)
+        let isDarkMode = (traitCollection.userInterfaceStyle == .dark)
+        weatherViewModel.loadWeatherAttribution(isDarkMode: isDarkMode)
         setupAttribution()
-        weatherViewModel.loadWeatherAttribution()
     }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            let isDarkMode = (traitCollection.userInterfaceStyle == .dark)
+            weatherViewModel.loadWeatherAttribution(isDarkMode: isDarkMode)
+        }
+    }
+
     
     //MARK: - @objc functions
     @objc private func TappedstartRunningButton() {
@@ -1027,7 +1038,7 @@ extension RunningMapViewController {
         backToRunningTimerViewButton.snp.makeConstraints {
             $0.width.height.equalTo(90)
             $0.leading.equalToSuperview().offset(10)
-            $0.bottom.equalToSuperview().offset(-120)
+            $0.bottom.equalToSuperview().offset(-130)
         }
         
         compassButton.snp.makeConstraints {
@@ -1112,7 +1123,7 @@ extension RunningMapViewController {
     
     func setupAttribution() {
         weatherViewModel.$weatherAttribution.receive(on: DispatchQueue.main).sink { [weak self] attributionImageURLString in
-            let url = URL(string: attributionImageURLString)
+            guard let url = URL(string: attributionImageURLString) else { return }
             self?.downloadAndSetAttributionImage(from: url)
         }.store(in: &cancellables)
     }

--- a/Run-It/RunningMapView/WeatherViewModel.swift
+++ b/Run-It/RunningMapView/WeatherViewModel.swift
@@ -72,17 +72,16 @@ class WeatherViewModel: ObservableObject {
 
 
 extension WeatherViewModel {
-    func loadWeatherAttribution() {
+    func loadWeatherAttribution(isDarkMode: Bool) {
         guard let url = URL(string: "https://weatherkit.apple.com/attribution/en-US") else { return }
 
         let task = URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
-
             guard let data = data, error == nil else { return }
-
             do {
                 let attributionData = try JSONDecoder().decode(AttributionData.self, from: data)
                 let baseURLString = "https://weatherkit.apple.com"
-                let imageURLString = baseURLString + attributionData.logoLight1x
+                // 인터페이스 스타일에 따라 이미지 URL을 선택합니다.
+                let imageURLString = isDarkMode ? baseURLString + attributionData.logoDark1x : baseURLString + attributionData.logoLight1x
                 
                 DispatchQueue.main.async {
                     self?.weatherAttribution = imageURLString
@@ -92,7 +91,6 @@ extension WeatherViewModel {
                 print(error)
             }
         }
-
         task.resume()
     }
 }


### PR DESCRIPTION
<!--
  Assignees - 본인 선택하기
  ReviewWers - 팀원 선택하기
-->

## Contents
<!-- 작업 사항에 대한 설명을 적어주세요 --> 
 즐겨찾기뷰 , 프로필뷰 상단 라벨 추가 및 고정
 프로필뷰 레이아웃 -  활동기록 셀 간격 조정 및 관련 레이아웃 조정
 다크모드 - 웨더킷 이미지 및 로그인/회원가입 텍스트 필드, 애플 로고이미지 반전 수정 (모두 코드로 수정)
 맵뷰 - 리스타트버튼 모달에 가려져서 레이아웃 조정 (10만큼 위로 올림)

## Screenshots
<!-- 작업 사항에 대한 스크린샷을 첨부해주세요 --> 
<img width="307" alt="스크린샷 2024-03-28 오후 3 04 05" src="https://github.com/Run-Eat/Run-It/assets/151702566/0c1874f8-60d8-494d-b8fa-ee214abce906">
<img width="312" alt="스크린샷 2024-03-28 오후 3 04 13" src="https://github.com/Run-Eat/Run-It/assets/151702566/6d771e0e-5523-457b-bdd6-bd82497e3738">
<img width="319" alt="스크린샷 2024-03-28 오후 1 07 28" src="https://github.com/Run-Eat/Run-It/assets/151702566/0530822e-ce95-4295-9443-1ce58d0bce78">
<img width="322" alt="스크린샷 2024-03-28 오후 1 07 33" src="https://github.com/Run-Eat/Run-It/assets/151702566/3d2e0986-c2ce-4f32-ab5e-7d06f1f00861">
<img width="321" alt="스크린샷 2024-03-28 오후 1 07 44" src="https://github.com/Run-Eat/Run-It/assets/151702566/110fd8cb-0497-4d9b-b6ec-f475c61cc2b6">

<img width="315" alt="스크린샷 2024-03-28 오후 2 56 58" src="https://github.com/Run-Eat/Run-It/assets/151702566/22234fef-3af7-4493-87c1-3b9762ce5e07">
<img width="304" alt="스크린샷 2024-03-28 오후 2 57 07" src="https://github.com/Run-Eat/Run-It/assets/151702566/1fbea70d-3bab-4653-8107-a2ab9a72e2d2">
<img width="330" alt="스크린샷 2024-03-28 오후 2 56 30" src="https://github.com/Run-Eat/Run-It/assets/151702566/0e03b9a8-ccfd-4b04-b04a-8b6189a36a18">



## To Reviewers
<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이나 논의할 부분이 있다면 적어주세요 --> 
기타 추후에 수정사항이 있으면 말씀 주세요.

## Issues
<!-- 이슈가 발생하는 부분이 있다면 적어주세요 -->

  
